### PR TITLE
Fix faulty formatting of stacktrace due to double escepe char

### DIFF
--- a/src/main/java/net/logstash/logging/log4j2/core/layout/LogStashJSONLayout.java
+++ b/src/main/java/net/logstash/logging/log4j2/core/layout/LogStashJSONLayout.java
@@ -402,7 +402,7 @@ public class LogStashJSONLayout extends AbstractStringLayout {
             final List<String> list = Throwables.toStringList(throwable);
             for (final String str : list) {
                 buf.append(Transform.escapeJsonControlCharacters(str));
-                buf.append("\\\\n");
+                buf.append("\\n");
             }
             buf.append("\"");
         }


### PR DESCRIPTION
I have verified that stacktraces in Kibana now display as expected
