### PR TITLE
avoid NullPointerException when log4j event context stack is null

### DIFF
--- a/src/main/java/net/logstash/logging/log4j2/core/layout/LogStashJSONLayout.java
+++ b/src/main/java/net/logstash/logging/log4j2/core/layout/LogStashJSONLayout.java
@@ -388,7 +388,7 @@ public class LogStashJSONLayout extends AbstractStringLayout {
         }
 
         //NDC
-        if (!excludeNDC && event.getContextStack().getDepth() > 0) {
+        if (!excludeNDC && event.getContextStack() != null && event.getContextStack().getDepth() > 0) {
             buf.append(COMMA);
             buf.append(this.eol);
             buf.append(this.indent2);


### PR DESCRIPTION
log4j 2.6.2 - org.apache.logging.log4j.core.impl.ReusableLogEventFactory line 4:
`result.setContextStack(ThreadContext.getDepth() == 0?null:ThreadContext.cloneStack());` sets the context stack to `null`
which later crashes net.logstash.logging.log4j2.core.layout.LogStashJSONLayout on line 391 (line 207 in logstash-3.1.1-finn-2):
`if(!this.excludeNDC && event.getContextStack().getDepth() > 0) {`

with the following stack:

```
2016-11-14 14:19:26,264 main ERROR An exception occurred processing Appender FINNAppender java.lang.NullPointerException
	at net.logstash.logging.log4j2.core.layout.LogStashJSONLayout.toSerializable(LogStashJSONLayout.java:391)
	at net.logstash.logging.log4j2.core.layout.LogStashJSONLayout.toSerializable(LogStashJSONLayout.java:165)
	at org.apache.logging.log4j.core.layout.AbstractStringLayout.toByteArray(AbstractStringLayout.java:253)
	at org.apache.logging.log4j.core.layout.AbstractLayout.encode(AbstractLayout.java:159)
	at org.apache.logging.log4j.core.layout.AbstractLayout.encode(AbstractLayout.java:36)
	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.directEncodeEvent(AbstractOutputStreamAppender.java:120)
	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.tryAppend(AbstractOutputStreamAppender.java:113)
	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.append(AbstractOutputStreamAppender.java:104)
	at no.finntech.commons.logging.FINNAppender.lambda$append$1(FINNAppender.java:337)
	at java.util.ArrayList.forEach(ArrayList.java:1249)
	at no.finntech.commons.logging.FINNAppender.append(FINNAppender.java:336)
	at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:155)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:128)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:119)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:84)
	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:390)
	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:375)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:359)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:349)
	at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:63)
	at org.apache.logging.log4j.core.Logger.logMessage(Logger.java:146)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:2011)
	at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:1884)
	at org.apache.logging.log4j.spi.AbstractLogger.warn(AbstractLogger.java:2644)
```